### PR TITLE
Fixes clipboard history ordering to be recent to oldest

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -404,7 +404,7 @@ impl Tile {
             }
 
             Message::ClipboardHistory(clip_content) => {
-                self.clipboard_content.push(clip_content);
+                self.clipboard_content.insert(0, clip_content);
                 Task::none()
             }
 


### PR DESCRIPTION
This makes it so that the recent clipboard items get added to the top of the list rather than the bottom