### PR TITLE
show clipboard history items even when query is empty

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -240,7 +240,7 @@ impl Tile {
                 self.query_lc = input.trim().to_lowercase();
                 self.query = input;
                 let prev_size = self.results.len();
-                if self.query_lc.is_empty() {
+                if self.query_lc.is_empty() && self.page == Page::Main {
                     self.results = vec![];
                     return window::resize(
                         id,


### PR DESCRIPTION
This allows the clipboard history items to be shown even when the query is an empty string