### PR TITLE
Remove Message::nothing

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -37,7 +37,6 @@ pub enum Message {
     ClearSearchQuery,
     ReloadConfig,
     ClipboardHistory(ClipBoardContentType),
-    _Nothing,
 }
 
 /// The window settings for rustcast

--- a/src/app/tile/elm.rs
+++ b/src/app/tile/elm.rs
@@ -73,11 +73,13 @@ pub fn view(tile: &Tile, wid: window::Id) -> Element<'_, Message> {
         let title_input = text_input(tile.config.placeholder.as_str(), &tile.query)
             .on_input(move |a| Message::SearchQueryChanged(a, wid))
             .on_paste(move |a| Message::SearchQueryChanged(a, wid))
-            .on_submit({
-                if tile.results.is_empty() {
-                    Message::_Nothing
+            .on_submit_maybe({
+                if !tile.results.is_empty() {
+                    Some(Message::RunFunction(
+                        tile.results.first().unwrap().to_owned().open_command,
+                    ))
                 } else {
-                    Message::RunFunction(tile.results.first().unwrap().to_owned().open_command)
+                    None
                 }
             })
             .id("query")

--- a/src/app/tile/update.rs
+++ b/src/app/tile/update.rs
@@ -146,14 +146,16 @@ pub fn handle_update(tile: &mut Tile, message: Message) -> Task<Message> {
                         operation::focus("query"),
                     )
                 } else {
+                    let clear_search_query = if tile.config.buffer_rules.clear_on_hide {
+                        Task::done(Message::ClearSearchQuery)
+                    } else {
+                        Task::none()
+                    };
+
                     let to_close = window::latest().map(|x| x.unwrap());
                     Task::batch([
                         to_close.map(Message::HideWindow),
-                        Task::done(if tile.config.buffer_rules.clone().clear_on_hide {
-                            Message::ClearSearchQuery
-                        } else {
-                            Message::_Nothing
-                        }),
+                        clear_search_query,
                         Task::done(Message::ReturnFocus),
                     ])
                 }
@@ -212,7 +214,5 @@ pub fn handle_update(tile: &mut Tile, message: Message) -> Task<Message> {
             tile.clipboard_content.insert(0, clip_content);
             Task::none()
         }
-
-        Message::_Nothing => Task::none(),
     }
 }


### PR DESCRIPTION
This removes the _Nothing variant from the message enum as by right it should not be used in the newer versions of iced. 