### PR TITLE
Only set menubar title to "RustCast" if app icon could not be loaded

### DIFF
--- a/src/app/menubar.rs
+++ b/src/app/menubar.rs
@@ -7,13 +7,14 @@ pub fn new_menu_icon(mtm: MainThreadMarker) {
     let status_item = status_bar.statusItemWithLength(NSVariableStatusItemLength);
 
     if let Some(button) = status_item.button(mtm) {
-        button.setTitle(&NSString::from_str("RustCast"));
         if let Some(image) = NSImage::imageNamed(&NSString::from_str("icon")) {
             image.setSize(NSSize {
                 width: 25.,
                 height: 25.,
             });
             button.setImage(Some(&image));
+        } else {
+            button.setTitle(&NSString::from_str("RustCast"));
         }
     }
 


### PR DESCRIPTION
This makes the status item / tray icon / menu bar icon only have a title if the image for the icon could not be loaded 