### PR TITLE
Update app description to be same height as app name

### DIFF
--- a/src/app/apps.rs
+++ b/src/app/apps.rs
@@ -151,7 +151,7 @@ impl App {
                         .font(theme.font())
                         .color(theme.text_color(0.4)),
                 )
-                .padding(12)
+                .padding(12),
             )
             .width(Fill);
 


### PR DESCRIPTION
Fix #89 

This fixes the issue where the app names are higher than the app descriptions