### PR TITLE
Fix esc key press

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -51,6 +51,7 @@ pub enum Message {
     RunFunction(Function),
     OpenFocused,
     ReturnFocus,
+    EscKeyPressed(Id),
     ClearSearchResults,
     WindowFocusChanged(Id, bool),
     ClearSearchQuery,

--- a/src/app/tile/update.rs
+++ b/src/app/tile/update.rs
@@ -63,6 +63,17 @@ pub fn handle_update(tile: &mut Tile, message: Message) -> Task<Message> {
             Task::none()
         }
 
+        Message::EscKeyPressed(id) => {
+            if tile.query_lc.is_empty() {
+                Task::done(Message::HideWindow(id))
+            } else {
+                Task::batch(vec![
+                    Task::done(Message::ClearSearchQuery),
+                    Task::done(Message::ClearSearchResults),
+                ])
+            }
+        }
+
         Message::SearchQueryChanged(input, id) => {
             tile.focus_id = 0;
             #[cfg(target_os = "macos")]


### PR DESCRIPTION
This makes the esc key hide the window if the search query has a query inside it, otherwise it will hide the window without requiring an additional key press.

Fixes #1 