### PR TITLE
Add direct shortcut to open clipboard history

### DIFF
--- a/src/app/tile.rs
+++ b/src/app/tile.rs
@@ -98,6 +98,7 @@ pub struct Tile {
     pub config: Config,
     /// The opening hotkey
     hotkey: HotKey,
+    clipboard_hotkey: Option<HotKey>,
     clipboard_content: Vec<ClipBoardContentType>,
     tray_icon: Option<TrayIcon>,
     sender: Option<ExtSender>,

--- a/src/app/tile/elm.rs
+++ b/src/app/tile/elm.rs
@@ -73,6 +73,10 @@ pub fn new(hotkey: HotKey, config: &Config) -> (Tile, Task<Message>) {
             emoji_apps: AppIndex::from_apps(App::emoji_apps()),
             hotkey,
             visible: true,
+            clipboard_hotkey: config
+                .clipboard_hotkey
+                .clone()
+                .and_then(|x| x.parse::<HotKey>().ok()),
             frontmost: None,
             focused: false,
             config: config.clone(),

--- a/src/config.rs
+++ b/src/config.rs
@@ -15,6 +15,7 @@ use crate::{
 #[serde(default)]
 pub struct Config {
     pub toggle_hotkey: String,
+    pub clipboard_hotkey: Option<String>,
     pub buffer_rules: Buffer,
     pub theme: Theme,
     pub placeholder: String,
@@ -29,6 +30,7 @@ impl Default for Config {
     fn default() -> Self {
         Self {
             toggle_hotkey: "ALT+SPACE".to_string(),
+            clipboard_hotkey: None,
             buffer_rules: Buffer::default(),
             theme: Theme::default(),
             placeholder: String::from("Time to be productive!"),

--- a/src/main.rs
+++ b/src/main.rs
@@ -44,8 +44,13 @@ fn main() -> iced::Result {
 
     let show_hide = config.toggle_hotkey.parse().unwrap();
 
-    // Hotkeys are stored as a vec so that hyperkey support can be added later
-    let hotkeys = vec![show_hide];
+    let mut hotkeys = vec![show_hide];
+
+    if let Some(show_clipboard) = &config.clipboard_hotkey
+        && let Some(cb_page_hk) = show_clipboard.parse().ok()
+    {
+        hotkeys.push(cb_page_hk);
+    }
 
     manager
         .register_all(&hotkeys)


### PR DESCRIPTION
This allows people to configure a cliboard history shortcut to open rustcast directly to the clipboard history page 