### PR TITLE
add a notification in the tray icon that an update is available

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2560,6 +2560,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "minreq"
+version = "2.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05015102dad0f7d61691ca347e9d9d9006685a64aefb3d79eecf62665de2153d"
+dependencies = [
+ "rustls",
+ "rustls-webpki",
+ "webpki-roots",
+]
+
+[[package]]
 name = "mio"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3776,6 +3787,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b34b781b31e5d73e9fbc8689c70551fd1ade9a19e3e28cfec8580a79290cc4"
 
 [[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.17",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "roxmltree"
 version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3816,6 +3841,7 @@ dependencies = [
  "image",
  "libc",
  "log",
+ "minreq",
  "objc2 0.6.3",
  "objc2-app-kit 0.3.2",
  "objc2-application-services",
@@ -3825,6 +3851,7 @@ dependencies = [
  "rand",
  "rayon",
  "serde",
+ "serde_json",
  "tokio",
  "toml 0.9.12+spec-1.1.0",
  "tracing-subscriber",
@@ -3859,6 +3886,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls"
+version = "0.21.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f56a14d1f48b391359b22f731fd4bd7e43c97f3c50eee276f3aa09c94784d3e"
+dependencies = [
+ "log",
+ "ring",
+ "rustls-webpki",
+ "sct",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.101.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
+dependencies = [
+ "ring",
+ "untrusted",
+]
+
+[[package]]
 name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3884,6 +3933,16 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "sct"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414"
+dependencies = [
+ "ring",
+ "untrusted",
+]
 
 [[package]]
 name = "sctk-adwaita"
@@ -4694,6 +4753,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
 name = "url"
 version = "2.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5045,6 +5110,12 @@ dependencies = [
  "js-sys",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "webpki-roots"
+version = "0.25.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f20c57d8d7db6d3b86154206ae5d8fba62dd39573114de97c2cb0578251f8e1"
 
 [[package]]
 name = "weezl"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ icns = "0.3.1"
 image = "0.25.9"
 libc = "0.2.180"
 log = "0.4.29"
+minreq = { version = "2.14.1", features = ["https"] }
 objc2 = "0.6.3"
 objc2-app-kit = { version = "0.3.2", features = ["NSImage"] }
 objc2-application-services = { version = "0.3.2", default-features = false, features = [
@@ -30,6 +31,7 @@ once_cell = "1.21.3"
 rand = "0.9.2"
 rayon = "1.11.0"
 serde = { version = "1.0.228", features = ["derive"] }
+serde_json = "1.0.149"
 tokio = { version = "1.48.0", features = ["full"] }
 toml = "0.9.8"
 tracing-subscriber = { version = "0.3.22", features = ["env-filter"] }

--- a/src/app.rs
+++ b/src/app.rs
@@ -49,6 +49,7 @@ pub enum Move {
 /// The message type that iced uses for actions that can do something
 #[derive(Debug, Clone)]
 pub enum Message {
+    UpdateAvailable,
     ResizeWindow(Id, f32),
     OpenWindow,
     SearchQueryChanged(String, Id),

--- a/src/app/menubar.rs
+++ b/src/app/menubar.rs
@@ -26,7 +26,7 @@ use tokio::runtime::Runtime;
 /// This create a new menubar icon for the app
 pub fn menu_icon(config: Config, sender: ExtSender) -> TrayIcon {
     let builder = TrayIconBuilder::new();
-    let menu = menu_builder(config, sender);
+    let menu = menu_builder(config, sender, false);
 
     let image = get_image();
     let icon = Icon::from_rgba(image.as_bytes().to_vec(), image.width(), image.height()).unwrap();
@@ -38,7 +38,7 @@ pub fn menu_icon(config: Config, sender: ExtSender) -> TrayIcon {
         .unwrap()
 }
 
-pub fn menu_builder(config: Config, sender: ExtSender) -> Menu {
+pub fn menu_builder(config: Config, sender: ExtSender, update_item: bool) -> Menu {
     let hotkey = config.toggle_hotkey.parse::<HotKey>().unwrap();
 
     let mut modes = config.modes;
@@ -49,6 +49,16 @@ pub fn menu_builder(config: Config, sender: ExtSender) -> Menu {
     init_event_handler(sender, hotkey.id());
 
     Menu::with_items(&[
+        &MenuItem::with_id(
+            "update",
+            if update_item {
+                "Update available"
+            } else {
+                "Up to date"
+            },
+            update_item,
+            None,
+        ),
         &version_item(),
         &about_item(get_image()),
         &open_github_item(),
@@ -103,6 +113,9 @@ fn init_event_handler(sender: ExtSender, hotkey_id: u32) {
                         .try_send(Message::KeyPressed(hotkey_id))
                         .unwrap();
                 });
+            }
+            "update" => {
+                open_url("https://github.com/unsecretised/rustcast/releases/latest");
             }
             "open_discord" => {
                 open_url(DISCORD_LINK);

--- a/src/app/tile.rs
+++ b/src/app/tile.rs
@@ -22,7 +22,7 @@ use iced::{
 };
 use iced::{event, window};
 
-use log::info;
+use log::{info, warn};
 use objc2::rc::Retained;
 use objc2_app_kit::NSRunningApplication;
 use rayon::iter::{IntoParallelRefIterator, ParallelIterator};
@@ -31,6 +31,7 @@ use tray_icon::TrayIcon;
 use std::fmt::Debug;
 use std::fs;
 use std::ops::Bound;
+use std::str::FromStr;
 use std::time::Duration;
 use std::{collections::BTreeMap, path::Path};
 
@@ -109,6 +110,7 @@ pub struct Tile {
     pub focus_id: u32,
     pub query: String,
     pub current_mode: String,
+    pub update_available: bool,
     query_lc: String,
     results: Vec<App>,
     options: AppIndex,
@@ -171,6 +173,7 @@ impl Tile {
             Subscription::run(handle_hotkeys),
             keyboard,
             Subscription::run(handle_recipient),
+            Subscription::run(check_version),
             Subscription::run(handle_hot_reloading),
             Subscription::run(handle_clipboard_history),
             window::close_events().map(Message::HideWindow),
@@ -390,6 +393,54 @@ fn handle_recipient() -> impl futures::Stream<Item = Message> {
                 abcd.await;
             }
             tokio::time::sleep(Duration::from_millis(100)).await;
+        }
+    })
+}
+
+fn check_version() -> impl futures::Stream<Item = Message> {
+    stream::channel(100, async |mut output| {
+        let current_version = format!("\"{}\"", option_env!("APP_VERSION").unwrap_or(""));
+
+        if current_version.is_empty() {
+            println!("empty version");
+            return;
+        }
+
+        let req = minreq::Request::new(
+            minreq::Method::Get,
+            "https://api.github.com/repos/unsecretised/rustcast/releases/latest",
+        )
+        .with_header("User-Agent", "rustcast-update-checker")
+        .with_header("Accept", "application/vnd.github+json")
+        .with_header("X-GitHub-Api-Version", "2022-11-28");
+
+        loop {
+            let resp = req
+                .clone()
+                .send()
+                .and_then(|x| x.as_str().map(serde_json::Value::from_str));
+
+            info!("Made a req for latest version");
+
+            if let Ok(Ok(val)) = resp {
+                let new_ver = val
+                    .get("name")
+                    .map(|x| x.to_string())
+                    .unwrap_or("".to_string());
+
+                // new_ver is in the format "\"v0.0.0\""
+                // note that it is encapsulated in double quotes
+                if new_ver.trim() != current_version
+                    && !new_ver.is_empty()
+                    && new_ver.starts_with("\"v")
+                {
+                    info!("new version available: {new_ver}");
+                    output.send(Message::UpdateAvailable).await.ok();
+                }
+            } else {
+                warn!("Error getting resp");
+            }
+            tokio::time::sleep(Duration::from_secs(60)).await;
         }
     })
 }

--- a/src/app/tile/elm.rs
+++ b/src/app/tile/elm.rs
@@ -62,6 +62,7 @@ pub fn new(hotkey: HotKey, config: &Config) -> (Tile, Task<Message>) {
 
     (
         Tile {
+            update_available: false,
             current_mode: "Default".to_string(),
             query: String::new(),
             query_lc: String::new(),

--- a/src/app/tile/update.rs
+++ b/src/app/tile/update.rs
@@ -45,6 +45,11 @@ pub fn handle_update(tile: &mut Tile, message: Message) -> Task<Message> {
             Task::none()
         }
 
+        Message::UpdateAvailable => {
+            tile.update_available = true;
+            Task::done(Message::ReloadConfig)
+        }
+
         Message::SwitchMode(mode) => {
             if let Some(command) = tile.config.modes.get(mode.trim()) {
                 tile.current_mode = mode.clone();
@@ -245,9 +250,15 @@ pub fn handle_update(tile: &mut Tile, message: Message) -> Task<Message> {
                 icon.set_menu(Some(Box::new(menu_builder(
                     new_config.clone(),
                     tile.sender.clone().unwrap(),
+                    tile.update_available,
                 ))));
             } else {
                 tile.tray_icon = Some(menu_icon(new_config.clone(), tile.sender.clone().unwrap()));
+                tile.tray_icon
+                    .as_mut()
+                    .unwrap()
+                    .set_visible(tile.config.show_trayicon)
+                    .ok();
             }
 
             let mut new_options = get_installed_apps(new_config.theme.show_icons);
@@ -542,7 +553,7 @@ pub fn handle_update(tile: &mut Tile, message: Message) -> Task<Message> {
                     .map(|conversion| conversion.to_app())
                     .collect();
                 return single_item_resize_task(id);
-            } else if let Some(res) = Expr::from_str(&tile.query).ok() {
+            } else if let Ok(res) = Expr::from_str(&tile.query) {
                 tile.results.push(App {
                     ranking: 0,
                     open_command: AppCommand::Function(Function::Calculate(res.clone())),


### PR DESCRIPTION
fixes #98 

This adds a notification in the tray icon that a new update is available. 

it uses the [minreq](https://crates.io/crates/minreq) crate and [github releases api](https://docs.github.com/en/rest/releases/releases?apiVersion=2022-11-28)