### PR TITLE
fix hotkeys not being registered on config reload

### DIFF
--- a/src/app/tile.rs
+++ b/src/app/tile.rs
@@ -10,7 +10,7 @@ use crate::{app::apps::App, platform::default_app_paths};
 
 use arboard::Clipboard;
 use global_hotkey::hotkey::HotKey;
-use global_hotkey::{GlobalHotKeyEvent, HotKeyState};
+use global_hotkey::{GlobalHotKeyEvent, GlobalHotKeyManager, HotKeyState};
 
 use iced::futures::SinkExt;
 use iced::futures::channel::mpsc::{Sender, channel};
@@ -134,6 +134,14 @@ pub struct Tile {
 pub struct Hotkeys {
     pub toggle: HotKey,
     pub clipboard_hotkey: HotKey,
+}
+
+impl Hotkeys {
+    pub fn register(&self) {
+        let manager = GlobalHotKeyManager::new().unwrap();
+        manager.register(self.toggle).ok();
+        manager.register(self.clipboard_hotkey).ok();
+    }
 }
 
 impl Tile {

--- a/src/app/tile/update.rs
+++ b/src/app/tile/update.rs
@@ -278,6 +278,8 @@ pub fn handle_update(tile: &mut Tile, message: Message) -> Task<Message> {
                     .unwrap_or(tile.hotkeys.clipboard_hotkey),
             };
 
+            tile.hotkeys.register();
+
             tile.theme = new_config.theme.to_owned().into();
             tile.config = new_config;
             tile.options = AppIndex::from_apps(new_options);


### PR DESCRIPTION
This fixes the hotkeys not being registered when config reloaded