### PR TITLE
add aliases to rustcast

### DIFF
--- a/src/app/tile/update.rs
+++ b/src/app/tile/update.rs
@@ -421,7 +421,11 @@ pub fn handle_update(tile: &mut Tile, message: Message) -> Task<Message> {
             }
 
             tile.query_lc = input.trim().to_lowercase();
-            tile.query = input;
+            tile.query = input.clone();
+
+            if let Some(alias) = tile.config.aliases.get(&input.trim().to_lowercase()) {
+                tile.query_lc = alias.to_string();
+            }
 
             let prev_size = tile.results.len();
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -27,6 +27,7 @@ pub struct Config {
     pub show_trayicon: bool,
     pub shells: Vec<Shelly>,
     pub modes: HashMap<String, String>,
+    pub aliases: HashMap<String, String>,
     pub log_path: String,
 }
 
@@ -44,6 +45,7 @@ impl Default for Config {
             show_trayicon: true,
             log_path: "/tmp/rustcast.log".to_string(),
             modes: HashMap::new(),
+            aliases: HashMap::new(),
             shells: vec![],
         }
     }


### PR DESCRIPTION
Fixes #193 
Adds aliases to rustcast

(needs an update to the wiki when the new release will be published)

simply use:
```toml
[aliases]
ff = "firefox"
```
to search for "firefox"

this allows people to use aliases as a alias to a search term instead of a app specific term