### PR TITLE
use esc key for going back to main page

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3868,7 +3868,7 @@ dependencies = [
 
 [[package]]
 name = "rustcast"
-version = "0.6.3"
+version = "0.6.7"
 dependencies = [
  "anyhow",
  "arboard",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustcast"
-version = "0.6.3"
+version = "0.6.7"
 edition = "2024"
 license = "MIT"
 description = "RustCast - Productivity app for macOS"

--- a/src/app.rs
+++ b/src/app.rs
@@ -30,6 +30,17 @@ pub enum Page {
     EmojiSearch,
 }
 
+impl std::fmt::Display for Page {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(match self.to_owned() {
+            Page::Main => "App search",
+            Page::FileSearch => "File search",
+            Page::EmojiSearch => "Emoji search",
+            Page::ClipboardHistory => "Clipboard history",
+        })
+    }
+}
+
 /// The types of arrow keys
 #[allow(dead_code)]
 #[derive(Debug, Clone)]

--- a/src/app/tile.rs
+++ b/src/app/tile.rs
@@ -184,9 +184,6 @@ impl Tile {
             keyboard::listen().filter_map(|event| {
                 if let keyboard::Event::KeyPressed { key, modifiers, .. } = event {
                     match key {
-                        keyboard::Key::Named(Named::Escape) => {
-                            return Some(Message::ReturnFocus);
-                        }
                         keyboard::Key::Named(Named::ArrowUp) => {
                             return Some(Message::ChangeFocus(ArrowKey::Up, 1));
                         }

--- a/src/app/tile/elm.rs
+++ b/src/app/tile/elm.rs
@@ -161,7 +161,7 @@ pub fn view(tile: &Tile, wid: window::Id) -> Element<'_, Message> {
                 format!("{results_count} results found")
             }
         } else {
-            String::from("♥️ Rustcast")
+            tile.page.to_string()
         };
 
         let contents = container(

--- a/src/app/tile/update.rs
+++ b/src/app/tile/update.rs
@@ -84,8 +84,8 @@ pub fn handle_update(tile: &mut Tile, message: Message) -> Task<Message> {
         }
 
         Message::EscKeyPressed(id) => {
-            if tile.page == Page::EmojiSearch && !tile.query_lc.is_empty() {
-                return Task::none();
+            if tile.page != Page::Main {
+                return Task::done(Message::SwitchToPage(Page::Main));
             }
 
             if tile.query_lc.is_empty() {


### PR DESCRIPTION
This allows you to use the `esc` key to go back to the main page

resolves #197 

I don't want to add a button because rustcast is meant to be keyboard oriented hence switching between app search, emoji page etc. won't make sense if its being done via a button. 