### PR TITLE
fix to default overwriting shells aliases modes and search dirs

### DIFF
--- a/src/app/tile/update.rs
+++ b/src/app/tile/update.rs
@@ -542,7 +542,13 @@ pub fn handle_update(tile: &mut Tile, message: Message) -> Task<Message> {
                 SetConfigFields::SetBufferFields(SetConfigBufferFields::ClearOnEnter(clear)) => {
                     final_config.buffer_rules.clear_on_enter = clear
                 }
-                SetConfigFields::ToDefault => final_config = Config::default(),
+                SetConfigFields::ToDefault => {
+                    final_config = Config::default();
+                    final_config.shells = tile.config.shells.clone();
+                    final_config.aliases = tile.config.aliases.clone();
+                    final_config.search_dirs = tile.config.search_dirs.clone();
+                    final_config.modes = tile.config.modes.clone();
+                }
             };
 
             tile.config = final_config;


### PR DESCRIPTION
fixes the to default behaviour (this is a temporary behaviour, this is incorrect behaviour once the settings UI is complete) 

Additionally a warning modal should be added before the to default button actually sets the default button / store a backup