### PR TITLE
feat: Assigning hotkeys to actions and quicklinks

### DIFF
--- a/src/app/tile.rs
+++ b/src/app/tile.rs
@@ -179,6 +179,7 @@ pub struct Tile {
 pub struct Hotkeys {
     pub toggle: HotKey,
     pub clipboard_hotkey: HotKey,
+    pub shells: HashMap<u32, String>,
 }
 
 impl Tile {

--- a/src/app/tile/elm.rs
+++ b/src/app/tile/elm.rs
@@ -60,12 +60,22 @@ pub fn new(hotkey: HotKey, config: &Config) -> (Tile, Task<Message>) {
     options.par_sort_by_key(|x| x.display_name.len());
     let options = AppIndex::from_apps(options);
 
+    let mut shells_map = HashMap::new();
+    for shell in &config.shells {
+        if let Some(hk_str) = &shell.hotkey
+            && let Ok(hk) = hk_str.parse::<HotKey>()
+        {
+            shells_map.insert(hk.id, shell.command.clone());
+        }
+    }
+
     let hotkeys = Hotkeys {
         toggle: hotkey,
         clipboard_hotkey: config
             .clipboard_hotkey
             .parse()
             .unwrap_or("SUPER+SHIFT+C".parse().unwrap()),
+        shells: shells_map,
     };
 
     let home = std::env::var("HOME").unwrap_or("/".to_string());

--- a/src/app/tile/update.rs
+++ b/src/app/tile/update.rs
@@ -284,6 +284,10 @@ pub fn handle_update(tile: &mut Tile, message: Message) -> Task<Message> {
         }
 
         Message::KeyPressed(hk_id) => {
+            if let Some(cmd) = tile.hotkeys.shells.get(&hk_id) {
+                return Task::done(Message::RunFunction(Function::RunShellCommand(cmd.clone())));
+            }
+
             let is_clipboard_hotkey = tile.hotkeys.clipboard_hotkey.id == hk_id;
             let is_open_hotkey = hk_id == tile.hotkeys.toggle.id;
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -180,10 +180,11 @@ impl Default for Buffer {
 /// Alias is the text that is used to call this command / search for it
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq)]
 pub struct Shelly {
-    command: String,
-    icon_path: Option<String>,
-    alias: String,
-    alias_lc: String,
+    pub command: String,
+    pub icon_path: Option<String>,
+    pub alias: String,
+    pub alias_lc: String,
+    pub hotkey: Option<String>,
 }
 
 impl ToApp for Shelly {

--- a/src/main.rs
+++ b/src/main.rs
@@ -76,11 +76,18 @@ fn main() -> iced::Result {
         .parse()
         .unwrap_or("SUPER+SHIFT+C".parse().unwrap());
 
-    let hotkeys = vec![show_hide, cbhist];
+    let mut hotkeys = vec![show_hide, cbhist];
+    for shell in &config.shells {
+        if let Some(hk_str) = &shell.hotkey
+            && let Ok(hk) = hk_str.parse::<HotKey>()
+        {
+            hotkeys.push(hk);
+        }
+    }
 
     manager
         .register_all(&hotkeys)
-        .expect("Unable to register hotkey");
+        .expect("Unable to register hotkeys");
 
     info!("Hotkeys loaded");
     info!("Starting rustcast");


### PR DESCRIPTION
This PR provides a requested feature in #235 

it adds a feature to assign global hotkeys to custom shell commands (Quicklinks), giving RustCast a Raycast-like shortcut functionality.

Users can now configure global keyboard shortcuts for any [[shells]] item in their  `config.toml`. When a shortcut is triggered, RustCast immediately executes the shell command in the background (e.g. launching an app or opening a URL) without requiring the user to open the RustCast search window.

How to Test
Open your RustCast configuration file at ~/.config/rustcast/config.toml.
Ensure there are no empty shells = [] declarations floating at the top of the file.
Add a custom mapped shell command to the bottom:

e.g

```
[[shells]]
alias = "Launch GitHub"
alias_lc = "github"
command = "open https://github.com"
hotkey = "CTRL+SHIFT+G"

[[shells]]
alias = "Launch VS Code"
alias_lc = "vscode"
command = "open -a 'Visual Studio Code'"
hotkey = "CTRL+SHIFT+V"

[[shells]]
alias = "Toggle Dark Mode"
alias_lc = "darkmode"
command = "osascript -e 'tell app \"System Events\" to tell appearance preferences to set dark mode to not dark mode'"
hotkey = "CTRL+SHIFT+D"

[[shells]]
alias = "Open Downloads"
alias_lc = "downloads"
command = "open ~/Downloads"
hotkey = "CTRL+SHIFT+M"
```

Below is a screen record:


https://github.com/user-attachments/assets/d67c9bec-a9e6-4eb5-826c-113b2ec3753d

