### PR TITLE
Enhance search_prefix to include prefix with hyphen #258

### DIFF
--- a/src/app/tile.rs
+++ b/src/app/tile.rs
@@ -54,7 +54,10 @@ impl AppIndex {
     /// Search for an element in the index that starts with the provided prefix
     fn search_prefix<'a>(&'a self, prefix: &'a str) -> impl ParallelIterator<Item = &'a App> + 'a {
         self.by_name.par_iter().filter_map(move |(name, app)| {
-            if name.starts_with(prefix) || name.contains(format!(" {prefix}").as_str()) {
+            if name.starts_with(prefix)
+                || name.contains(format!(" {prefix}").as_str())
+                || name.contains(format!("-{prefix}").as_str())
+            {
                 Some(app)
             } else {
                 None


### PR DESCRIPTION
### Problem

When searching for a partial word, apps with hyphenated names (e.g. `Karabiner-Elements`) were not returned in results — even though Raycast correctly surfaces them. Searching `ele` would fail to match `karabiner-elements` because the search only recognized spaces as word boundaries.

### Root Cause

The `search_prefix` method in `AppIndex` checked two conditions:
1. The app's `search_name` starts with the query
2. The `search_name` contains a **space** followed by the query (`" ele"`)

Hyphenated names like `karabiner-elements` don't satisfy either condition for a mid-word query, so they were silently dropped from results.

### Fix

Added a third condition to also match when a **hyphen** precedes the query prefix, treating `-` as a word boundary on par with spaces.

```rust
// Before
if name.starts_with(prefix) || name.contains(format!(" {prefix}").as_str()) {

// After
if name.starts_with(prefix)
    || name.contains(format!(" {prefix}").as_str())
    || name.contains(format!("-{prefix}").as_str()) {
```

### Files Changed

- `src/app/tile.rs` — `AppIndex::search_prefix`

### Testing

- Searching `ele` now returns `Karabiner-Elements`
- Searching `kara` continues to return `Karabiner-Elements` (starts_with path)
- Existing behavior for space-separated and single-word app names is unaffected

Closes #258